### PR TITLE
Fix RuntimeError in loc_inference.py when using --data_device cpu

### DIFF
--- a/warping/warping_loss.py
+++ b/warping/warping_loss.py
@@ -45,7 +45,11 @@ def compute_warping_loss(vr, qr, quat_opt, t_opt, pose, K, depth):
     warp = pose @ from_cam_tensor_to_w2c(torch.cat([quat_opt, t_opt], dim=0)).inverse()
     
     warped_image = differentiable_warp(vr.unsqueeze(0), depth.unsqueeze(0), warp.unsqueeze(0), K.unsqueeze(0))
-    loss = F.mse_loss(warped_image, qr.unsqueeze(0))
+    target_qr = qr.unsqueeze(0)
+    if target_qr.device != warped_image.device:
+        target_qr = target_qr.to(warped_image.device)
+        
+    loss = F.mse_loss(warped_image, target_qr)
 
     return loss
 


### PR DESCRIPTION
## Description
This PR fixes a `RuntimeError: Expected all tensors to be on the same device` that occurs during localization inference (`loc_inference.py`) when the model is trained with `--data_device cpu`.

## Motivation and Context
When training with `--data_device cpu` to save VRAM, the ground truth images (`qr`) remain on the CPU. However, the rendered images (`warped_image`) are computed on the GPU. This causes a device mismatch in `compute_warping_loss` when calculating `F.mse_loss`.

## How has this been tested?
I trained the model on the 7Scenes Chess dataset using `--data_device cpu` and ran `loc_inference.py`.
- **Before fix:** Crashed with `RuntimeError` at `warping_loss.py`.
- **After fix:** Localization inference completes successfully without errors.

## Changes
- Added a check in `warping/warping_loss.py` to move the target tensor (`qr`) to the same device as the input tensor (`warped_image`) before loss calculation.